### PR TITLE
Catch error in issue #35 where no reference UMIs are produced

### DIFF
--- a/scripts/umi_binning.sh
+++ b/scripts/umi_binning.sh
@@ -270,6 +270,17 @@ $GAWK \
   $UMI_DIR/umi12c.fa \
   > $UMI_DIR/umi12cf.fa 
 
+# Check that there were umi_ref sequences with which to bin putative UMIs
+if [ $(grep -c '^>' $UMI_DIR/umi12cf.fa) = 0 ]; then
+  echo
+  echo "Pipeline stopped!"
+  echo "The pipeline has not produced any umi_ref sequences for the umi mapping.\
+  none of the perfect UMIs detected have a coverage > 3."
+  echo "Cluster sizes of perfect UMIs in $UMI_DIR/umi12c.fa";
+  echo "This result is usually due to the molecule/data ratio in the library being too low";
+  exit 1;
+fi
+
 # Remove potential chimeras
 paste <(cat $UMI_DIR/umi12cf.fa | paste - - ) \
   <($GAWK '!/^>/{print}' $UMI_DIR/umi12cf.fa | rev | tr ATCG TAGC) |\


### PR DESCRIPTION
I made a simple test to catch the error in issue #35. It counts the sequences in the output of `umi12cf.fa` . The script exits if there are zero sequences an gives an error message that suggests what the problem may have been (based on your text in the issue). 